### PR TITLE
Add atlas i18n language menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ YSL collects the public Yellowstone National Park sound library and turns it int
 
 The atlas is a static listening interface built from this repository's media files.
 
+It supports English, Simplified Chinese, Japanese, and Korean. Use the in-page language switcher to change player labels, specimen notes, theme navigation, and share copy without leaving the current sound.
+
 ```bash
 python -m http.server 8000
 ```
@@ -102,6 +104,8 @@ YSL 收集 Yellowstone National Park 的公开声音库，并把这些音频和�
 - `tests/`：爬虫、图谱数据、静态页面和预览服务测试。
 
 ### 本地预览
+
+图谱支持英文、简体中文、日文与韩文。可以使用页面内的语言切换器，在不中断当前声音的情况下切换播放器标签、标本札记、主题导航与分享文案。
 
 ```bash
 python -m http.server 8000

--- a/atlas/css/main.css
+++ b/atlas/css/main.css
@@ -626,6 +626,7 @@ figure {
 
 .stamp-rule-top {
   position: relative;
+  flex-wrap: wrap;
   padding-right: 42px;
 }
 
@@ -639,6 +640,154 @@ figure {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.language-switcher {
+  position: relative;
+  display: inline-block;
+  margin-left: auto;
+}
+
+.language-menu-button {
+  min-height: 34px;
+  min-width: 62px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 0 10px;
+  border: 1px solid var(--line-soft);
+  border-radius: 999px;
+  background:
+    linear-gradient(180deg, color-mix(in oklch, var(--bone-high) 82%, transparent), color-mix(in oklch, var(--bone) 58%, transparent));
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  line-height: 1;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+.language-icon {
+  width: 17px;
+  height: 17px;
+  flex: 0 0 auto;
+  stroke-width: 1.8;
+}
+
+.language-current-label {
+  padding-left: 5px;
+  border-left: 1px solid currentColor;
+  font-size: 0.52rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  opacity: 0.72;
+  text-transform: uppercase;
+}
+
+.language-menu-button:hover,
+.language-switcher.is-open .language-menu-button {
+  border-color: color-mix(in oklch, var(--theme-color) 62%, var(--line));
+  color: var(--ink);
+  transform: translateY(-1px);
+}
+
+.language-menu-button:active {
+  transform: translateY(1px);
+}
+
+.language-menu-button:focus-visible {
+  outline: 2px solid var(--theme-color);
+  outline-offset: 2px;
+}
+
+.language-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 10px);
+  z-index: 24;
+  width: 188px;
+  padding: 6px;
+  border: 1px solid oklch(36% 0.05 82 / 0.54);
+  background:
+    radial-gradient(circle at 92% 8%, color-mix(in oklch, var(--theme-color) 16%, transparent), transparent 5.5rem),
+    linear-gradient(180deg, var(--bone-high), var(--bone) 64%, var(--bone-deep));
+  box-shadow:
+    0 1px 0 oklch(100% 0 0 / 0.66) inset,
+    0 18px 54px oklch(4% 0.02 85 / 0.42);
+  color: var(--ink);
+  transform-origin: right bottom;
+  animation: language-menu-in 160ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.language-menu[hidden] {
+  display: none;
+}
+
+.language-menu button {
+  position: relative;
+  min-height: 34px;
+  width: 100%;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 0 30px 0 10px;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  background: transparent;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-weight: 800;
+  line-height: 1;
+  text-align: left;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+.language-menu button:hover,
+.language-menu button:focus-visible {
+  border-color: color-mix(in oklch, var(--theme-color) 38%, var(--line-soft));
+  background: color-mix(in oklch, var(--theme-color) 10%, transparent);
+  color: var(--ink);
+  outline: none;
+}
+
+.language-menu button[aria-checked="true"] {
+  border-color: color-mix(in oklch, var(--theme-color) 48%, var(--line-soft));
+  background: color-mix(in oklch, var(--theme-color) 16%, var(--bone-high));
+  color: var(--ink);
+}
+
+.language-menu button[aria-checked="true"]::after {
+  content: "";
+  position: absolute;
+  right: 10px;
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--theme-color);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--theme-color) 18%, transparent);
+}
+
+.language-menu-name {
+  overflow: hidden;
+  font-size: 0.66rem;
+  letter-spacing: 0.02em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.language-menu-code {
+  font-size: 0.52rem;
+  letter-spacing: 0.04em;
+  opacity: 0.62;
+  text-transform: uppercase;
 }
 
 .minimize-btn {
@@ -1186,12 +1335,36 @@ figure {
 }
 
 .archive-slip {
-  grid-column: 2;
-  grid-row: 1;
-  align-self: center;
-  justify-self: end;
   position: relative;
   z-index: 3;
+}
+
+.strip-actions {
+  grid-column: 2;
+  grid-row: 1;
+  display: flex;
+  align-items: center;
+  justify-self: end;
+  gap: 8px;
+  min-width: 0;
+}
+
+.specimen-strip .language-switcher {
+  margin-left: 0;
+}
+
+.specimen-strip .language-menu-button {
+  border-color: oklch(94% 0.03 88 / 0.22);
+  background:
+    linear-gradient(180deg, oklch(94% 0.03 88 / 0.08), oklch(94% 0.03 88 / 0.03));
+  color: oklch(94% 0.03 88 / 0.68);
+}
+
+.specimen-strip .language-menu-button:hover,
+.specimen-strip .language-switcher.is-open .language-menu-button {
+  border-color: color-mix(in oklch, var(--theme-color) 62%, oklch(94% 0.03 88 / 0.26));
+  background: color-mix(in oklch, var(--theme-color) 14%, transparent);
+  color: var(--bone);
 }
 
 .archive-slip summary {
@@ -1454,6 +1627,18 @@ figure {
   to {
     opacity: 1;
     transform: translate3d(0, 0, 0) rotate(0deg);
+  }
+}
+
+@keyframes language-menu-in {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 6px, 0) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
   }
 }
 
@@ -1772,6 +1957,21 @@ body.player-is-minimized .keyboard-hints {
     font-size: 0.56rem;
   }
 
+  .stamp-rule-top {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    padding-right: 42px;
+  }
+
+  .stamp-rule-top .eyebrow {
+    grid-column: 1;
+  }
+
+  .volume-mark {
+    grid-column: 2;
+  }
+
   .track-title {
     font-size: 2rem;
   }
@@ -1847,16 +2047,66 @@ body.player-is-minimized .keyboard-hints {
   }
 
   .specimen-strip {
-    grid-template-rows: 38px minmax(0, 1fr);
+    grid-template-rows: 44px minmax(0, 1fr);
     gap: 0;
     padding: 2px 10px calc(4px + env(safe-area-inset-bottom));
   }
 
   .archive-slip summary {
     justify-content: center;
-    width: 38px;
-    min-height: 32px;
+    width: 40px;
+    min-height: 40px;
     padding: 0;
+  }
+
+  .strip-actions {
+    gap: 6px;
+  }
+
+  .specimen-strip .language-switcher {
+    position: fixed;
+    top: max(14px, calc(env(safe-area-inset-top) + 14px));
+    right: max(14px, calc(env(safe-area-inset-right) + 14px));
+    z-index: 28;
+  }
+
+  .specimen-strip .language-menu-button {
+    width: 40px;
+    min-width: 40px;
+    min-height: 40px;
+    padding: 0;
+    border-color: var(--line-soft);
+    background:
+      radial-gradient(circle at 35% 18%, oklch(100% 0 0 / 0.55), transparent 58%),
+      linear-gradient(180deg, var(--bone-high), var(--bone) 70%, var(--bone-deep));
+    color: var(--ink-soft);
+    box-shadow:
+      0 1px 0 oklch(100% 0 0 / 0.56) inset,
+      0 8px 18px oklch(4% 0.02 85 / 0.18);
+  }
+
+  .specimen-strip .language-menu-button:hover,
+  .specimen-strip .language-switcher.is-open .language-menu-button {
+    border-color: color-mix(in oklch, var(--theme-color) 50%, var(--line));
+    background: color-mix(in oklch, var(--theme-color) 14%, var(--bone-high));
+    color: var(--ink);
+  }
+
+  .language-icon {
+    width: 18px;
+    height: 18px;
+  }
+
+  .language-current-label {
+    display: none;
+  }
+
+  .language-menu {
+    top: calc(100% + 8px);
+    right: 0;
+    bottom: auto;
+    width: min(188px, calc(100vw - 20px));
+    transform-origin: right top;
   }
 
   .archive-slip summary span:last-child {

--- a/atlas/index.html
+++ b/atlas/index.html
@@ -91,7 +91,7 @@
       <section class="stamp-face stamp-expanded" aria-label="Active sound specimen">
         <header class="stamp-rule stamp-rule-top">
           <p class="eyebrow" id="eyebrow">YELLOWSTONE - 01</p>
-          <p class="volume-mark">VOL 61</p>
+          <p class="volume-mark" id="volume-mark">VOL 61</p>
           <button id="minimize-btn" class="minimize-btn" type="button" aria-label="Minimize player">
             <svg viewBox="0 0 24 24" aria-hidden="true">
               <path d="M7 10l5 5 5-5"></path>
@@ -156,8 +156,8 @@
         </div>
 
         <footer class="stamp-rule stamp-rule-bottom">
-          <span>National Park Service source</span>
-          <span>Specimen archive</span>
+          <span id="stamp-source-label">National Park Service source</span>
+          <span id="stamp-archive-label">Specimen archive</span>
         </footer>
       </section>
 
@@ -167,7 +167,7 @@
       >
         <div class="mini-rule">
           <span id="mini-eyebrow">YELLOWSTONE - 01</span>
-          <span>VOL 61</span>
+        <span id="mini-volume-mark">VOL 61</span>
         </div>
         <figure class="mini-photo-frame" id="mini-photo-frame">
           <img id="mini-scene-photo" alt="" decoding="async">
@@ -193,54 +193,95 @@
 
   <nav class="specimen-strip" id="specimen-strip" aria-label="Theme specimen navigation">
     <div class="theme-tabs" id="theme-tabs" role="tablist" aria-label="Specimen themes"></div>
-    <details class="archive-slip" id="archive-slip">
-      <summary id="archive-slip-summary" aria-label="Open project archive slip">
-        <span class="archive-slip-mark" aria-hidden="true">i</span>
-        <span>Archive slip</span>
-      </summary>
-      <section class="archive-slip-card" aria-label="Project colophon">
-        <p class="archive-slip-kicker">COLOPHON</p>
-        <h2>Yellowstone Sound Atlas</h2>
-        <p>
-          A static listening route built from the public Yellowstone Sound Library,
-          arranged as specimen stamps and field notes.
-        </p>
-        <dl>
-          <div>
-            <dt>Repository</dt>
-            <dd><a href="https://github.com/rosuH/YSL" target="_blank" rel="noopener">GitHub</a></dd>
-          </div>
-          <div>
-            <dt>Full archive</dt>
-            <dd><a href="https://archive.org/details/YSL.7z" target="_blank" rel="noopener">Web Archive</a></dd>
-          </div>
-          <div>
-            <dt>Source</dt>
-            <dd><a href="https://www.nps.gov/yell/learn/photosmultimedia/soundlibrary.htm" target="_blank" rel="noopener">National Park Service</a></dd>
-          </div>
-        </dl>
-        <p class="archive-slip-fine">
-          Not an official National Park Service product. NPS labels these audio files as public domain,
-          but users should verify third-party rights for their own use. If a file should be removed,
-          <a href="https://github.com/rosuH/YSL/issues" target="_blank" rel="noopener">open an issue</a>.
-        </p>
-      </section>
-    </details>
+    <div class="strip-actions">
+      <div id="language-switcher" class="language-switcher" role="group" aria-label="Language">
+        <button
+          id="language-menu-button"
+          class="language-menu-button"
+          type="button"
+          aria-haspopup="menu"
+          aria-expanded="false"
+          aria-controls="language-menu"
+          aria-label="Language"
+        >
+          <svg class="language-icon" data-icon="languages" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="m5 8 6 6"></path>
+            <path d="m4 14 6-6 2-3"></path>
+            <path d="M2 5h12"></path>
+            <path d="M7 2h1"></path>
+            <path d="m22 22-5-10-5 10"></path>
+            <path d="M14 18h6"></path>
+          </svg>
+          <span id="language-current-label" class="language-current-label">EN</span>
+        </button>
+        <div id="language-menu" class="language-menu" role="menu" aria-labelledby="language-menu-button" hidden>
+          <button type="button" role="menuitemradio" data-locale="en" aria-checked="true">
+            <span class="language-menu-name">English</span>
+            <span class="language-menu-code">EN</span>
+          </button>
+          <button type="button" role="menuitemradio" data-locale="zh" aria-checked="false">
+            <span class="language-menu-name">简体中文</span>
+            <span class="language-menu-code">中</span>
+          </button>
+          <button type="button" role="menuitemradio" data-locale="ja" aria-checked="false">
+            <span class="language-menu-name">日本語</span>
+            <span class="language-menu-code">日</span>
+          </button>
+          <button type="button" role="menuitemradio" data-locale="ko" aria-checked="false">
+            <span class="language-menu-name">한국어</span>
+            <span class="language-menu-code">한</span>
+          </button>
+        </div>
+      </div>
+      <details class="archive-slip" id="archive-slip">
+        <summary id="archive-slip-summary" aria-label="Open project archive slip">
+          <span class="archive-slip-mark" aria-hidden="true">i</span>
+          <span id="archive-slip-summary-text">Archive slip</span>
+        </summary>
+        <section class="archive-slip-card" aria-label="Project colophon">
+          <p class="archive-slip-kicker" id="archive-slip-kicker">COLOPHON</p>
+          <h2 id="archive-slip-title">Yellowstone Sound Atlas</h2>
+          <p id="archive-slip-body">
+            A static listening route built from the public Yellowstone Sound Library,
+            arranged as specimen stamps and field notes.
+          </p>
+          <dl>
+            <div>
+              <dt id="archive-repository-label">Repository</dt>
+              <dd><a href="https://github.com/rosuH/YSL" target="_blank" rel="noopener">GitHub</a></dd>
+            </div>
+            <div>
+              <dt id="archive-full-label">Full archive</dt>
+              <dd><a href="https://archive.org/details/YSL.7z" target="_blank" rel="noopener">Web Archive</a></dd>
+            </div>
+            <div>
+              <dt id="archive-source-label">Source</dt>
+              <dd><a href="https://www.nps.gov/yell/learn/photosmultimedia/soundlibrary.htm" target="_blank" rel="noopener">National Park Service</a></dd>
+            </div>
+          </dl>
+          <p class="archive-slip-fine" id="archive-slip-fine">
+            Not an official National Park Service product. NPS labels these audio files as public domain,
+            but users should verify third-party rights for their own use. If a file should be removed,
+            <a href="https://github.com/rosuH/YSL/issues" target="_blank" rel="noopener">open an issue</a>.
+          </p>
+        </section>
+      </details>
+    </div>
     <div class="chip-carousel" id="chip-carousel" aria-label="Theme specimens"></div>
   </nav>
 
   <p class="status" id="status" role="status" aria-live="polite"></p>
 
   <div class="keyboard-hints" id="keyboard-hints" aria-hidden="true">
-    <kbd>Space <span>Play/Pause</span></kbd>
-    <kbd>Alt + Left <span>Prev</span></kbd>
-    <kbd>Alt + Right <span>Next</span></kbd>
-    <kbd>M <span>Minimize</span></kbd>
+    <kbd>Space <span id="keyboard-space-label">Play/Pause</span></kbd>
+    <kbd>Alt + Left <span id="keyboard-prev-label">Prev</span></kbd>
+    <kbd>Alt + Right <span id="keyboard-next-label">Next</span></kbd>
+    <kbd>M <span id="keyboard-minimize-label">Minimize</span></kbd>
   </div>
 
   <noscript>
     <div class="noscript-notice">
-      <p>This experience requires JavaScript to load the sound specimens.</p>
+      <p id="noscript-copy">This experience requires JavaScript to load the sound specimens.</p>
     </div>
   </noscript>
 

--- a/atlas/index.html
+++ b/atlas/index.html
@@ -112,7 +112,7 @@
 
         <div class="waveform" id="waveform" aria-hidden="true"></div>
 
-        <div class="controls" role="group" aria-label="Audio controls">
+        <div class="controls" id="audio-controls" role="group" aria-label="Audio controls">
           <button id="prev-btn" class="ctrl-btn" type="button" aria-label="Previous stop">
             <svg viewBox="0 0 24 24" aria-hidden="true">
               <path d="M15 6l-6 6 6 6"></path>

--- a/atlas/js/app.js
+++ b/atlas/js/app.js
@@ -49,7 +49,9 @@ const ui = {
   shareInstagram: getEl("#share-instagram-btn"),
   shareX: getEl("#share-x-link"),
   shareCopy: getEl("#share-copy-btn"),
+  shareDock: getEl("#share-dock"),
   stage: getEl("#stage"),
+  audioControls: getEl("#audio-controls"),
   expandedFace: document.querySelector(".stamp-expanded"),
   miniStamp: getEl("#mini-stamp"),
   miniExpand: getEl("#mini-expand-btn"),
@@ -182,6 +184,9 @@ function renderStaticCopy() {
 
   document.documentElement.lang = state.locale;
   document.title = text.documentTitle;
+  ui.stage.setAttribute("aria-label", text.siteLabel);
+  ui.shareDock.setAttribute("aria-label", text.shareDock);
+  ui.audioControls.setAttribute("aria-label", text.audioControls);
   ui.volumeMark.textContent = text.volume;
   ui.miniVolumeMark.textContent = text.volume;
   ui.backdropNote.querySelector(".backdrop-note-kicker").textContent = text.fieldNote;
@@ -423,10 +428,6 @@ function setBackdropImage(src, title) {
   } else {
     ui.itemBackdrop.style.removeProperty("background-image");
   }
-}
-
-function descriptionForStop(stop) {
-  return displayStop(stop).fieldNote || displayStop(stop).description;
 }
 
 function currentStop() {

--- a/atlas/js/app.js
+++ b/atlas/js/app.js
@@ -824,7 +824,12 @@ function moveLanguageFocus(direction) {
   const items = languageMenuItems();
   if (!items.length) return;
 
-  const currentIndex = Math.max(0, items.indexOf(document.activeElement));
+  const currentIndex = items.indexOf(document.activeElement);
+  if (currentIndex === -1) {
+    activeLanguageItem()?.focus();
+    return;
+  }
+
   const nextIndex = (currentIndex + direction + items.length) % items.length;
   items[nextIndex].focus();
 }

--- a/atlas/js/app.js
+++ b/atlas/js/app.js
@@ -1,5 +1,17 @@
-const ROUTE_URL = "./dawn-to-night.json";
+import {
+  LOCALE_LABELS,
+  localeFromUrl,
+  localizeStop,
+  localizeThemeName,
+  localizedCredit,
+  normalizeLocale,
+  setStoredLocale,
+  shareHashtags,
+  shareText,
+  uiText,
+} from "./i18n.js";
 
+const ROUTE_URL = "./dawn-to-night.json";
 const THEME_ORDER = ["Thermal", "Birds", "Wildlife", "Human", "Weather", "Ambient", "Water"];
 
 const THEME_META = {
@@ -16,6 +28,7 @@ const state = {
   stops: [],
   index: 0,
   activeTheme: "Thermal",
+  locale: localeFromUrl(),
   isPlaying: false,
   isDragging: false,
   isMinimized: false,
@@ -40,7 +53,13 @@ const ui = {
   expandedFace: document.querySelector(".stamp-expanded"),
   miniStamp: getEl("#mini-stamp"),
   miniExpand: getEl("#mini-expand-btn"),
+  languageSwitcher: getEl("#language-switcher"),
+  languageMenuButton: getEl("#language-menu-button"),
+  languageMenu: getEl("#language-menu"),
+  languageCurrentLabel: getEl("#language-current-label"),
   eyebrow: getEl("#eyebrow"),
+  volumeMark: getEl("#volume-mark"),
+  miniVolumeMark: getEl("#mini-volume-mark"),
   title: getEl("#track-title"),
   meta: getEl("#track-meta"),
   desc: getEl("#track-desc"),
@@ -75,6 +94,20 @@ const ui = {
   strip: getEl("#specimen-strip"),
   archiveSlip: getEl("#archive-slip"),
   archiveSlipSummary: getEl("#archive-slip-summary"),
+  archiveSlipSummaryText: getEl("#archive-slip-summary-text"),
+  archiveSlipKicker: getEl("#archive-slip-kicker"),
+  archiveSlipTitle: getEl("#archive-slip-title"),
+  archiveSlipBody: getEl("#archive-slip-body"),
+  archiveRepositoryLabel: getEl("#archive-repository-label"),
+  archiveFullLabel: getEl("#archive-full-label"),
+  archiveSourceLabel: getEl("#archive-source-label"),
+  archiveSlipFine: getEl("#archive-slip-fine"),
+  stampSourceLabel: getEl("#stamp-source-label"),
+  stampArchiveLabel: getEl("#stamp-archive-label"),
+  keyboardSpaceLabel: getEl("#keyboard-space-label"),
+  keyboardPrevLabel: getEl("#keyboard-prev-label"),
+  keyboardNextLabel: getEl("#keyboard-next-label"),
+  keyboardMinimizeLabel: getEl("#keyboard-minimize-label"),
 };
 
 if (!ui.playerCard) throw new Error("Missing element: .player-card");
@@ -84,6 +117,105 @@ function getEl(selector) {
   const el = document.querySelector(selector);
   if (!el) throw new Error(`Missing element: ${selector}`);
   return el;
+}
+
+function copy() {
+  return uiText(state.locale);
+}
+
+function displayStop(stop) {
+  return localizeStop(stop, state.locale);
+}
+
+function languageMenuItems() {
+  return Array.from(ui.languageMenu.querySelectorAll("[data-locale]"));
+}
+
+function activeLanguageItem() {
+  return ui.languageMenu.querySelector(`[data-locale="${state.locale}"]`) || languageMenuItems()[0];
+}
+
+function isLanguageMenuOpen() {
+  return !ui.languageMenu.hidden;
+}
+
+function setLanguageMenuOpen(open, options = {}) {
+  ui.languageMenu.hidden = !open;
+  ui.languageSwitcher.classList.toggle("is-open", open);
+  ui.languageMenuButton.setAttribute("aria-expanded", String(open));
+
+  if (open && options.focusActive) {
+    activeLanguageItem()?.focus();
+  } else if (!open && options.returnFocus) {
+    ui.languageMenuButton.focus();
+  }
+}
+
+function renderLanguageSwitcher() {
+  const text = copy();
+  const activeButton = activeLanguageItem();
+
+  ui.languageSwitcher.setAttribute("aria-label", text.language);
+  ui.languageMenuButton.setAttribute("aria-label", text.chooseLanguage);
+  ui.languageMenuButton.title = text.chooseLanguage;
+  ui.languageMenuButton.setAttribute("aria-expanded", String(isLanguageMenuOpen()));
+  ui.languageCurrentLabel.textContent =
+    activeButton?.querySelector(".language-menu-code")?.textContent?.trim() || state.locale.toUpperCase();
+  languageMenuItems().forEach((button) => {
+    const locale = normalizeLocale(button.dataset.locale);
+    const active = locale === state.locale;
+    button.setAttribute("aria-checked", String(active));
+    button.setAttribute("aria-label", text.languageOption(LOCALE_LABELS[locale]));
+  });
+}
+
+function syncLocaleUrl() {
+  if (!window.history || typeof window.history.replaceState !== "function") return;
+
+  const url = new URL(window.location.href);
+  url.searchParams.set("lang", state.locale);
+  window.history.replaceState(null, "", url);
+}
+
+function renderStaticCopy() {
+  const text = copy();
+
+  document.documentElement.lang = state.locale;
+  document.title = text.documentTitle;
+  ui.volumeMark.textContent = text.volume;
+  ui.miniVolumeMark.textContent = text.volume;
+  ui.backdropNote.querySelector(".backdrop-note-kicker").textContent = text.fieldNote;
+  ui.shareInstagram.setAttribute("aria-label", text.shareInstagram);
+  ui.shareInstagram.title = text.shareInstagramTitle;
+  ui.shareX.setAttribute("aria-label", text.postToX);
+  ui.shareX.title = text.postToXTitle;
+  ui.shareCopy.setAttribute("aria-label", text.copyLink);
+  ui.shareCopy.title = text.copyLinkTitle;
+  ui.prev.setAttribute("aria-label", text.previous);
+  ui.next.setAttribute("aria-label", text.next);
+  ui.track.setAttribute("aria-label", text.playbackPosition);
+  ui.strip.setAttribute("aria-label", text.stripLabel);
+  ui.themeTabs.setAttribute("aria-label", text.themeTabs);
+  ui.chipCarousel.setAttribute("aria-label", text.themeSpecimens);
+  ui.archiveSlipSummary.setAttribute("aria-label", text.archiveSlipSummary);
+  ui.archiveSlipSummaryText.textContent = text.archiveSlip;
+  ui.archiveSlip.querySelector(".archive-slip-card").setAttribute("aria-label", text.archiveCardLabel);
+  ui.archiveSlipKicker.textContent = text.colophon;
+  ui.archiveSlipTitle.textContent = text.archiveTitle;
+  ui.archiveSlipBody.textContent = text.archiveBody;
+  ui.archiveRepositoryLabel.textContent = text.repository;
+  ui.archiveFullLabel.textContent = text.fullArchive;
+  ui.archiveSourceLabel.textContent = text.sourceLabel;
+  ui.archiveSlipFine.textContent = text.archiveFine;
+  ui.stampSourceLabel.textContent = text.source;
+  ui.stampArchiveLabel.textContent = text.archive;
+  ui.keyboardSpaceLabel.textContent = text.keyboardSpace;
+  ui.keyboardPrevLabel.textContent = text.keyboardPrev;
+  ui.keyboardNextLabel.textContent = text.keyboardNext;
+  ui.keyboardMinimizeLabel.textContent = text.keyboardMinimize;
+  renderLanguageSwitcher();
+  updatePlayIcon();
+  applyMinimized(state.isMinimized);
 }
 
 function fmtTime(sec) {
@@ -294,7 +426,7 @@ function setBackdropImage(src, title) {
 }
 
 function descriptionForStop(stop) {
-  return stop.fieldNote || stop.description;
+  return displayStop(stop).fieldNote || displayStop(stop).description;
 }
 
 function currentStop() {
@@ -302,14 +434,16 @@ function currentStop() {
 }
 
 function setBackdropNote(stop) {
-  ui.backdropNoteTitle.textContent = stop.title;
-  ui.backdropNoteMeta.textContent = `${stop.theme} - ${stop.zoneLabel} - ${stop.timeOfDay}`;
-  ui.backdropNoteBody.textContent = descriptionForStop(stop);
+  const localized = displayStop(stop);
+  ui.backdropNoteTitle.textContent = localized.title;
+  ui.backdropNoteMeta.textContent = copy().noteMeta(localized.theme, localized.zoneLabel, localized.timeOfDay);
+  ui.backdropNoteBody.textContent = localized.fieldNote || localized.description;
 }
 
 function setBackdropPrint(stop, src) {
   const expectedId = stop.id;
-  const caption = `${stop.title} - ${stop.theme} - ${stop.timeOfDay}`;
+  const localized = displayStop(stop);
+  const caption = copy().printCaption(localized.title, localized.theme, localized.timeOfDay);
 
   ui.backdropPrintCaption.textContent = caption;
   ui.backdropPrintPhoto.alt = "";
@@ -347,16 +481,19 @@ function atlasBaseUrl() {
 }
 
 function shareUrlForStop(stop) {
-  return new URL(`share/${encodeURIComponent(stop.id)}/`, atlasBaseUrl()).toString();
+  const url = new URL(`share/${encodeURIComponent(stop.id)}/`, atlasBaseUrl());
+  url.searchParams.set("lang", state.locale);
+  return url.toString();
 }
 
 function shareTextForStop(stop) {
-  return `Yellowstone Sound Atlas: ${stop.title} - ${stop.theme}, ${stop.timeOfDay}.`;
+  return shareText(stop, state.locale);
 }
 
 function sharePayloadForStop(stop) {
+  const localized = displayStop(stop);
   return {
-    title: `${stop.title} - Yellowstone Sound Atlas`,
+    title: copy().shareTitle(localized.title),
     text: shareTextForStop(stop),
     url: shareUrlForStop(stop),
   };
@@ -366,7 +503,7 @@ function xIntentForStop(stop) {
   const intent = new URL("https://twitter.com/intent/tweet");
   intent.searchParams.set("text", shareTextForStop(stop));
   intent.searchParams.set("url", shareUrlForStop(stop));
-  intent.searchParams.set("hashtags", "Yellowstone,Soundscape");
+  intent.searchParams.set("hashtags", shareHashtags(state.locale));
   return intent.toString();
 }
 
@@ -404,7 +541,7 @@ async function copyText(text) {
   if (!copied) throw new Error("Copy command failed.");
 }
 
-async function copyShareLink(message = "Specimen link copied.") {
+async function copyShareLink(message = copy().copied) {
   const stop = currentStop();
   if (!stop) return;
 
@@ -413,7 +550,7 @@ async function copyShareLink(message = "Specimen link copied.") {
     confirmShareButton(ui.shareCopy);
     showStatus(message);
   } catch {
-    showStatus("Copy unavailable in this browser.", true);
+    showStatus(copy().copyUnavailable, true);
   }
 }
 
@@ -423,7 +560,7 @@ async function shareToInstalledApps() {
 
   const payload = sharePayloadForStop(stop);
   if (!navigator.share) {
-    await copyShareLink("Link copied for Instagram.");
+    await copyShareLink(copy().instagramCopied);
     return;
   }
 
@@ -432,7 +569,7 @@ async function shareToInstalledApps() {
     confirmShareButton(ui.shareInstagram);
   } catch (err) {
     if (!err || err.name !== "AbortError") {
-      await copyShareLink("Share unavailable. Link copied.");
+      await copyShareLink(copy().shareUnavailableCopied);
     }
   }
 }
@@ -459,9 +596,10 @@ function updateAtmosphere(stop) {
   const fallbackPalette = semanticPaletteForStop(stop);
   const imageSrc = stop.imagePath ? encodeURI(`../${stop.imagePath}`) : "";
   const expectedId = stop.id;
+  const localized = displayStop(stop);
 
   applyDerivedPalette(fallbackPalette);
-  setBackdropImage(imageSrc, stop.title);
+  setBackdropImage(imageSrc, localized.title);
   setBackdropNote(stop);
   setBackdropPrint(stop, imageSrc);
 
@@ -537,6 +675,7 @@ function buildThemeTabs() {
 
   THEME_ORDER.forEach((theme) => {
     const meta = getThemeMeta(theme);
+    const themeLabel = localizeThemeName(theme, state.locale);
     const button = document.createElement("button");
     button.type = "button";
     button.className = "theme-tab";
@@ -547,7 +686,7 @@ function buildThemeTabs() {
     button.setAttribute("role", "tab");
     button.setAttribute("aria-controls", "chip-carousel");
     button.setAttribute("aria-selected", String(theme === state.activeTheme));
-    button.setAttribute("aria-label", `${theme}, ${themeCount(theme)} specimens`);
+    button.setAttribute("aria-label", copy().selectTheme(themeLabel, themeCount(theme)));
     button.addEventListener("click", () => setActiveTheme(theme, true));
 
     const swatch = document.createElement("span");
@@ -556,7 +695,7 @@ function buildThemeTabs() {
 
     const name = document.createElement("span");
     name.className = "theme-name";
-    name.textContent = theme;
+    name.textContent = themeLabel;
 
     const count = document.createElement("span");
     count.className = "theme-count";
@@ -572,12 +711,13 @@ function buildChipCarousel() {
 
   themeStops(state.activeTheme).forEach((stop) => {
     const meta = getThemeMeta(stop.theme);
+    const localized = displayStop(stop);
     const chip = document.createElement("button");
     chip.type = "button";
     chip.className = "specimen-chip stamp-chip";
     chip.dataset.index = String(stop.index);
     chip.style.setProperty("--theme-color", meta.color);
-    chip.setAttribute("aria-label", `Select ${stop.title}`);
+    chip.setAttribute("aria-label", copy().selectStop(localized.title));
     chip.addEventListener("click", () => {
       selectStop(stop.index, !ui.audio.paused, { keepActiveTheme: true });
     });
@@ -593,13 +733,13 @@ function buildChipCarousel() {
     }
 
     const label = document.createElement("small");
-    label.textContent = `${getStopNumber(stop.index)} - ${stop.timeOfDay}`;
+    label.textContent = `${getStopNumber(stop.index)} - ${localized.timeOfDay}`;
 
     const title = document.createElement("strong");
-    title.textContent = stop.title;
+    title.textContent = localized.title;
 
     const theme = document.createElement("span");
-    theme.textContent = stop.theme;
+    theme.textContent = localized.theme;
 
     chip.append(label, title, theme);
     ui.chipCarousel.appendChild(chip);
@@ -633,6 +773,90 @@ function updateThemeNav() {
       inline: "center",
       block: "nearest",
     });
+  }
+}
+
+function updateLocalizedSurface() {
+  renderStaticCopy();
+  if (!state.stops.length) return;
+
+  buildThemeTabs();
+  buildChipCarousel();
+  const stop = currentStop();
+  if (stop) {
+    const imageSrc = stop.imagePath ? encodeURI(`../${stop.imagePath}`) : "";
+    const localized = displayStop(stop);
+    const stopNumber = getStopNumber(state.index);
+    ui.eyebrow.textContent = copy().eyebrow(stopNumber);
+    ui.miniEyebrow.textContent = copy().eyebrow(stopNumber);
+    ui.title.textContent = localized.title;
+    ui.miniTitle.textContent = localized.title;
+    ui.meta.textContent = copy().noteMeta(localized.theme, localized.zoneLabel, localized.timeOfDay);
+    ui.miniMeta.textContent = `${localized.theme} - ${localized.timeOfDay}`;
+    ui.desc.textContent = localized.fieldNote || localized.description;
+    ui.credit.textContent = creditForStop(stop);
+    setBackdropImage(imageSrc, localized.title);
+    setBackdropNote(stop);
+    setBackdropPrint(stop, imageSrc);
+    updateScenePhoto(stop);
+    updateShareTargets(stop);
+  }
+  updateThemeNav();
+}
+
+function setLocale(locale) {
+  const nextLocale = normalizeLocale(locale);
+  if (nextLocale === state.locale) return;
+
+  state.locale = nextLocale;
+  setStoredLocale(nextLocale);
+  syncLocaleUrl();
+  updateLocalizedSurface();
+}
+
+function selectLanguage(locale) {
+  setLocale(locale);
+  setLanguageMenuOpen(false, { returnFocus: true });
+}
+
+function moveLanguageFocus(direction) {
+  const items = languageMenuItems();
+  if (!items.length) return;
+
+  const currentIndex = Math.max(0, items.indexOf(document.activeElement));
+  const nextIndex = (currentIndex + direction + items.length) % items.length;
+  items[nextIndex].focus();
+}
+
+function onLanguageMenuKeydown(e) {
+  const target = e.target instanceof Element ? e.target.closest("[data-locale]") : null;
+
+  if (e.key === "Escape") {
+    e.preventDefault();
+    setLanguageMenuOpen(false, { returnFocus: true });
+  } else if (e.key === "ArrowDown") {
+    e.preventDefault();
+    if (!isLanguageMenuOpen()) {
+      setLanguageMenuOpen(true, { focusActive: true });
+    } else {
+      moveLanguageFocus(1);
+    }
+  } else if (e.key === "ArrowUp") {
+    e.preventDefault();
+    if (!isLanguageMenuOpen()) {
+      setLanguageMenuOpen(true, { focusActive: true });
+    } else {
+      moveLanguageFocus(-1);
+    }
+  } else if (e.key === "Home" && isLanguageMenuOpen()) {
+    e.preventDefault();
+    languageMenuItems()[0]?.focus();
+  } else if (e.key === "End" && isLanguageMenuOpen()) {
+    e.preventDefault();
+    languageMenuItems().at(-1)?.focus();
+  } else if ((e.key === "Enter" || e.key === " ") && target) {
+    e.preventDefault();
+    selectLanguage(target.dataset.locale);
   }
 }
 
@@ -698,15 +922,15 @@ function setActiveTheme(theme, selectFirst = false) {
   });
 }
 
-function setPhoto(img, frame, imagePath, title) {
+function setPhoto(img, frame, imagePath, sourceTitle, displayTitle = sourceTitle) {
   const expectedPath = imagePath || "";
   const matchesSelectedStop = () => {
     const selected = state.stops[state.index];
-    return selected && selected.title === title && (selected.imagePath || "") === expectedPath;
+    return selected && selected.title === sourceTitle && (selected.imagePath || "") === expectedPath;
   };
 
-  img.alt = title || "";
-  frame.dataset.fallbackLabel = title || "Sound specimen";
+  img.alt = displayTitle || "";
+  frame.dataset.fallbackLabel = displayTitle || copy().routeSpecimen;
   img.classList.remove("is-loaded");
 
   if (!imagePath) {
@@ -741,13 +965,13 @@ function setPhoto(img, frame, imagePath, title) {
 }
 
 function updateScenePhoto(stop) {
-  setPhoto(ui.scenePhoto, ui.sceneFrame, stop.imagePath, stop.title);
-  setPhoto(ui.miniScenePhoto, ui.miniFrame, stop.imagePath, stop.title);
+  const localized = displayStop(stop);
+  setPhoto(ui.scenePhoto, ui.sceneFrame, stop.imagePath, stop.title, localized.title);
+  setPhoto(ui.miniScenePhoto, ui.miniFrame, stop.imagePath, stop.title, localized.title);
 }
 
 function creditForStop(stop) {
-  if (stop.imagePath) return stop.credit;
-  return stop.credit.replace("Audio and image", "Audio");
+  return localizedCredit(stop, state.locale);
 }
 
 function applyMinimized(nextValue) {
@@ -760,7 +984,7 @@ function applyMinimized(nextValue) {
   ui.shareCopy.tabIndex = state.isMinimized ? 0 : -1;
   ui.minimizeBtn.setAttribute(
     "aria-label",
-    state.isMinimized ? "Expand player" : "Minimize player",
+    state.isMinimized ? copy().expand : copy().minimize,
   );
   ui.miniExpand.disabled = !state.isMinimized;
 }
@@ -801,6 +1025,7 @@ function selectStop(index, autoPlay = false, options = {}) {
   if (!state.stops[index]) return;
 
   const stop = state.stops[index];
+  const localized = displayStop(stop);
   const previousTheme = state.activeTheme;
   const themeMeta = getThemeMeta(stop.theme);
 
@@ -814,13 +1039,13 @@ function selectStop(index, autoPlay = false, options = {}) {
   ui.body.classList.add("is-switching");
 
   const stopNumber = getStopNumber(index);
-  ui.eyebrow.textContent = `YELLOWSTONE - ${stopNumber}`;
-  ui.miniEyebrow.textContent = `YELLOWSTONE - ${stopNumber}`;
-  ui.title.textContent = stop.title;
-  ui.miniTitle.textContent = stop.title;
-  ui.meta.textContent = `${stop.theme} - ${stop.zoneLabel} - ${stop.timeOfDay}`;
-  ui.miniMeta.textContent = `${stop.theme} - ${stop.timeOfDay}`;
-  ui.desc.textContent = descriptionForStop(stop);
+  ui.eyebrow.textContent = copy().eyebrow(stopNumber);
+  ui.miniEyebrow.textContent = copy().eyebrow(stopNumber);
+  ui.title.textContent = localized.title;
+  ui.miniTitle.textContent = localized.title;
+  ui.meta.textContent = copy().noteMeta(localized.theme, localized.zoneLabel, localized.timeOfDay);
+  ui.miniMeta.textContent = `${localized.theme} - ${localized.timeOfDay}`;
+  ui.desc.textContent = localized.fieldNote || localized.description;
   ui.credit.textContent = creditForStop(stop);
   updateShareTargets(stop);
   syncLocationHash(stop);
@@ -839,7 +1064,7 @@ function selectStop(index, autoPlay = false, options = {}) {
   } else {
     ui.audio.play().catch(() => {
       updatePlayIcon();
-      showStatus("Playback could not start automatically.");
+      showStatus(copy().autoPlayFailed);
     });
   }
 
@@ -879,8 +1104,8 @@ function updatePlayIcon() {
   ui.iconPause.style.display = playing ? "block" : "none";
   ui.miniIconPlay.style.display = playing ? "none" : "block";
   ui.miniIconPause.style.display = playing ? "block" : "none";
-  ui.play.setAttribute("aria-label", playing ? "Pause" : "Play");
-  ui.miniPlay.setAttribute("aria-label", playing ? "Pause" : "Play");
+  ui.play.setAttribute("aria-label", playing ? copy().pause : copy().play);
+  ui.miniPlay.setAttribute("aria-label", playing ? copy().pause : copy().play);
   ui.waveform.classList.toggle("playing", playing);
 }
 
@@ -1002,6 +1227,16 @@ ui.track.addEventListener("keydown", (e) => {
 });
 
 ui.themeTabs.addEventListener("keydown", onThemeTabsKeydown);
+ui.languageMenuButton.addEventListener("click", (e) => {
+  e.stopPropagation();
+  setLanguageMenuOpen(!isLanguageMenuOpen(), { focusActive: !isLanguageMenuOpen() });
+});
+ui.languageMenu.addEventListener("click", (e) => {
+  const button = e.target instanceof Element ? e.target.closest("[data-locale]") : null;
+  if (!button) return;
+  selectLanguage(button.dataset.locale);
+});
+ui.languageSwitcher.addEventListener("keydown", onLanguageMenuKeydown);
 ui.play.addEventListener("click", togglePlay);
 ui.miniPlay.addEventListener("click", (e) => {
   e.stopPropagation();
@@ -1042,7 +1277,7 @@ ui.audio.addEventListener("error", () => {
   stopProgressAnimation();
   setPlayDisabled(true);
   updatePlayIcon();
-  showStatus("Audio unavailable for this specimen.", true);
+  showStatus(copy().audioUnavailable, true);
 });
 
 function isTextEntryTarget(target) {
@@ -1059,7 +1294,10 @@ document.addEventListener("keydown", (e) => {
   if (e.defaultPrevented) return;
   if (isTextEntryTarget(e.target)) return;
 
-  if (e.code === "Escape" && ui.archiveSlip.open) {
+  if (e.code === "Escape" && isLanguageMenuOpen()) {
+    e.preventDefault();
+    setLanguageMenuOpen(false, { returnFocus: true });
+  } else if (e.code === "Escape" && ui.archiveSlip.open) {
     e.preventDefault();
     closeArchiveSlip();
     ui.archiveSlipSummary.focus();
@@ -1084,6 +1322,7 @@ document.addEventListener("keydown", (e) => {
 
 document.addEventListener("click", (e) => {
   if (!(e.target instanceof Node)) return;
+  if (isLanguageMenuOpen() && !ui.languageSwitcher.contains(e.target)) setLanguageMenuOpen(false);
   if (ui.archiveSlip.open && !ui.archiveSlip.contains(e.target)) closeArchiveSlip();
 });
 
@@ -1128,14 +1367,16 @@ async function loadRoute() {
     buildChipCarousel();
     setMinimized(false);
     selectStop(startingIndex);
-    showStatus(`${stops.length} sound specimens loaded`);
+    showStatus(copy().statusLoaded(stops.length));
   } catch (err) {
     showStatus(err.message, true);
-    ui.title.textContent = "Unable to load route";
+    ui.title.textContent = copy().routeLoadFailed;
     ui.desc.textContent = err.message;
   }
 }
 
+syncLocaleUrl();
+renderStaticCopy();
 applyMinimized(false);
 updatePlayIcon();
 

--- a/atlas/js/i18n.js
+++ b/atlas/js/i18n.js
@@ -1,0 +1,537 @@
+export const DEFAULT_LOCALE = "en";
+export const SUPPORTED_LOCALES = ["en", "zh", "ja", "ko"];
+
+const STORAGE_KEY = "ysl-atlas-locale";
+
+export const LOCALE_LABELS = {
+  en: "English",
+  zh: "简体中文",
+  ja: "日本語",
+  ko: "한국어",
+};
+
+const UI_COPY = {
+  en: {
+    documentTitle: "Yellowstone Sound Atlas - Specimen Stamps",
+    siteLabel: "Yellowstone Sound Atlas",
+    fieldNote: "FIELD NOTE",
+    loadingTitle: "Loading...",
+    routeSpecimen: "Route specimen",
+    loadingDescription: "Loading the first Yellowstone sound specimen.",
+    shareDock: "Share current field note",
+    shareInstagram: "Share through device sheet for Instagram",
+    shareInstagramTitle: "Instagram / system share",
+    postToX: "Post this specimen to X",
+    postToXTitle: "Post to X",
+    copyLink: "Copy specimen link",
+    copyLinkTitle: "Copy link",
+    copied: "Specimen link copied.",
+    copyUnavailable: "Copy unavailable in this browser.",
+    instagramCopied: "Link copied for Instagram.",
+    shareUnavailableCopied: "Share unavailable. Link copied.",
+    minimize: "Minimize player",
+    expand: "Expand player",
+    play: "Play",
+    pause: "Pause",
+    previous: "Previous stop",
+    next: "Next stop",
+    audioControls: "Audio controls",
+    playbackPosition: "Playback position",
+    source: "National Park Service source",
+    archive: "Specimen archive",
+    volume: "VOL 61",
+    stripLabel: "Theme specimen navigation",
+    themeTabs: "Specimen themes",
+    themeSpecimens: "Theme specimens",
+    archiveSlipSummary: "Open project archive slip",
+    archiveSlip: "Archive slip",
+    archiveCardLabel: "Project colophon",
+    colophon: "COLOPHON",
+    archiveTitle: "Yellowstone Sound Atlas",
+    archiveBody: "A static listening route built from the public Yellowstone Sound Library, arranged as specimen stamps and field notes.",
+    repository: "Repository",
+    fullArchive: "Full archive",
+    sourceLabel: "Source",
+    archiveFine:
+      "Not an official National Park Service product. NPS labels these audio files as public domain, but users should verify third-party rights for their own use. If a file should be removed, open an issue.",
+    github: "GitHub",
+    webArchive: "Web Archive",
+    nationalParkService: "National Park Service",
+    statusLoaded: (count) => `${count} sound specimens loaded`,
+    routeLoadFailed: "Unable to load route",
+    autoPlayFailed: "Playback could not start automatically.",
+    audioUnavailable: "Audio unavailable for this specimen.",
+    language: "Language",
+    chooseLanguage: "Choose language",
+    languageOption: (name) => `Show atlas in ${name}`,
+    selectTheme: (theme, count) => `${theme}, ${count} specimens`,
+    selectStop: (title) => `Select ${title}`,
+    timeCurrent: "Current time",
+    timeTotal: "Total time",
+    keyboardSpace: "Play/Pause",
+    keyboardPrev: "Prev",
+    keyboardNext: "Next",
+    keyboardMinimize: "Minimize",
+    noScript: "This experience requires JavaScript to load the sound specimens.",
+    shareText: (title, theme, time) => `Yellowstone Sound Atlas: ${title} - ${theme}, ${time}.`,
+    shareTitle: (title) => `${title} - Yellowstone Sound Atlas`,
+    printCaption: (title, theme, time) => `${title} - ${theme} - ${time}`,
+    noteMeta: (theme, zone, time) => `${theme} - ${zone} - ${time}`,
+    eyebrow: (number) => `YELLOWSTONE - ${number}`,
+  },
+  zh: {
+    documentTitle: "黄石声音图谱 - 标本邮票",
+    siteLabel: "黄石声音图谱",
+    fieldNote: "野外札记",
+    loadingTitle: "加载中...",
+    routeSpecimen: "路线标本",
+    loadingDescription: "正在载入第一枚黄石声音标本。",
+    shareDock: "分享当前野外札记",
+    shareInstagram: "通过系统分享面板发送",
+    shareInstagramTitle: "Instagram / 系统分享",
+    postToX: "发布这枚标本到 X",
+    postToXTitle: "发布到 X",
+    copyLink: "复制标本链接",
+    copyLinkTitle: "复制链接",
+    copied: "标本链接已复制。",
+    copyUnavailable: "当前浏览器无法复制。",
+    instagramCopied: "已复制可用于 Instagram 的链接。",
+    shareUnavailableCopied: "分享不可用，链接已复制。",
+    minimize: "收起播放器",
+    expand: "展开播放器",
+    play: "播放",
+    pause: "暂停",
+    previous: "上一个站点",
+    next: "下一个站点",
+    audioControls: "音频控件",
+    playbackPosition: "播放位置",
+    source: "National Park Service 来源",
+    archive: "标本档案",
+    volume: "第 61 卷",
+    stripLabel: "主题标本导航",
+    themeTabs: "标本主题",
+    themeSpecimens: "主题标本",
+    archiveSlipSummary: "打开项目档案签",
+    archiveSlip: "档案签",
+    archiveCardLabel: "项目题跋",
+    colophon: "题跋",
+    archiveTitle: "黄石声音图谱",
+    archiveBody: "一个静态聆听路线，取材自黄石公共声音库，并以标本邮票与野外札记的方式编排。",
+    repository: "仓库",
+    fullArchive: "完整归档",
+    sourceLabel: "来源",
+    archiveFine:
+      "这不是 National Park Service 官方产品。NPS 将这些音频标记为公共领域，但使用者仍应自行核实第三方权利。如需移除文件，请提交 issue。",
+    github: "GitHub",
+    webArchive: "Web Archive",
+    nationalParkService: "National Park Service",
+    statusLoaded: (count) => `已加载 ${count} 枚声音标本`,
+    routeLoadFailed: "无法加载路线",
+    autoPlayFailed: "无法自动开始播放。",
+    audioUnavailable: "这枚标本的音频暂不可用。",
+    language: "语言",
+    chooseLanguage: "选择语言",
+    languageOption: (name) => `切换为${name}`,
+    selectTheme: (theme, count) => `${theme}，${count} 枚标本`,
+    selectStop: (title) => `选择${title}`,
+    timeCurrent: "当前时间",
+    timeTotal: "总时长",
+    keyboardSpace: "播放/暂停",
+    keyboardPrev: "上一个",
+    keyboardNext: "下一个",
+    keyboardMinimize: "收起",
+    noScript: "此体验需要 JavaScript 来加载声音标本。",
+    shareText: (title, theme, time) => `黄石声音图谱：${title} - ${theme}，${time}。`,
+    shareTitle: (title) => `${title} - 黄石声音图谱`,
+    printCaption: (title, theme, time) => `${title} - ${theme} - ${time}`,
+    noteMeta: (theme, zone, time) => `${theme} - ${zone} - ${time}`,
+    eyebrow: (number) => `黄石 - ${number}`,
+  },
+  ja: {
+    documentTitle: "イエローストーン・サウンドアトラス - 標本切手",
+    siteLabel: "イエローストーン・サウンドアトラス",
+    fieldNote: "フィールドノート",
+    loadingTitle: "読み込み中...",
+    routeSpecimen: "ルート標本",
+    loadingDescription: "最初のイエローストーン音標本を読み込んでいます。",
+    shareDock: "現在のフィールドノートを共有",
+    shareInstagram: "デバイスの共有シートで送信",
+    shareInstagramTitle: "Instagram / システム共有",
+    postToX: "この標本を X に投稿",
+    postToXTitle: "X に投稿",
+    copyLink: "標本リンクをコピー",
+    copyLinkTitle: "リンクをコピー",
+    copied: "標本リンクをコピーしました。",
+    copyUnavailable: "このブラウザではコピーできません。",
+    instagramCopied: "Instagram 用のリンクをコピーしました。",
+    shareUnavailableCopied: "共有できません。リンクをコピーしました。",
+    minimize: "プレイヤーを縮小",
+    expand: "プレイヤーを展開",
+    play: "再生",
+    pause: "一時停止",
+    previous: "前の地点",
+    next: "次の地点",
+    audioControls: "音声コントロール",
+    playbackPosition: "再生位置",
+    source: "National Park Service ソース",
+    archive: "標本アーカイブ",
+    volume: "VOL 61",
+    stripLabel: "テーマ標本ナビゲーション",
+    themeTabs: "標本テーマ",
+    themeSpecimens: "テーマ標本",
+    archiveSlipSummary: "プロジェクトのアーカイブ票を開く",
+    archiveSlip: "アーカイブ票",
+    archiveCardLabel: "プロジェクト奥付",
+    colophon: "奥付",
+    archiveTitle: "イエローストーン・サウンドアトラス",
+    archiveBody: "イエローストーン公開音源ライブラリをもとに、標本切手とフィールドノートとして編成した静的なリスニングルートです。",
+    repository: "リポジトリ",
+    fullArchive: "完全アーカイブ",
+    sourceLabel: "ソース",
+    archiveFine:
+      "これは National Park Service の公式製品ではありません。NPS はこれらの音声をパブリックドメインとしていますが、利用者は第三者権利を各自確認してください。削除が必要なファイルがあれば issue を開いてください。",
+    github: "GitHub",
+    webArchive: "Web Archive",
+    nationalParkService: "National Park Service",
+    statusLoaded: (count) => `${count}件の音標本を読み込みました`,
+    routeLoadFailed: "ルートを読み込めません",
+    autoPlayFailed: "自動再生を開始できませんでした。",
+    audioUnavailable: "この標本の音声は利用できません。",
+    language: "言語",
+    chooseLanguage: "言語を選択",
+    languageOption: (name) => `${name}で表示`,
+    selectTheme: (theme, count) => `${theme}、${count}件の標本`,
+    selectStop: (title) => `${title}を選択`,
+    timeCurrent: "現在の時間",
+    timeTotal: "合計時間",
+    keyboardSpace: "再生/一時停止",
+    keyboardPrev: "前へ",
+    keyboardNext: "次へ",
+    keyboardMinimize: "縮小",
+    noScript: "この体験で音標本を読み込むには JavaScript が必要です。",
+    shareText: (title, theme, time) => `イエローストーン・サウンドアトラス：${title} - ${theme}、${time}。`,
+    shareTitle: (title) => `${title} - イエローストーン・サウンドアトラス`,
+    printCaption: (title, theme, time) => `${title} - ${theme} - ${time}`,
+    noteMeta: (theme, zone, time) => `${theme} - ${zone} - ${time}`,
+    eyebrow: (number) => `イエローストーン - ${number}`,
+  },
+  ko: {
+    documentTitle: "옐로스톤 사운드 아틀라스 - 표본 우표",
+    siteLabel: "옐로스톤 사운드 아틀라스",
+    fieldNote: "필드 노트",
+    loadingTitle: "불러오는 중...",
+    routeSpecimen: "루트 표본",
+    loadingDescription: "첫 번째 옐로스톤 사운드 표본을 불러오는 중입니다.",
+    shareDock: "현재 필드 노트 공유",
+    shareInstagram: "기기 공유 시트로 보내기",
+    shareInstagramTitle: "Instagram / 시스템 공유",
+    postToX: "이 표본을 X에 게시",
+    postToXTitle: "X에 게시",
+    copyLink: "표본 링크 복사",
+    copyLinkTitle: "링크 복사",
+    copied: "표본 링크를 복사했습니다.",
+    copyUnavailable: "이 브라우저에서는 복사할 수 없습니다.",
+    instagramCopied: "Instagram용 링크를 복사했습니다.",
+    shareUnavailableCopied: "공유할 수 없어 링크를 복사했습니다.",
+    minimize: "플레이어 접기",
+    expand: "플레이어 펼치기",
+    play: "재생",
+    pause: "일시정지",
+    previous: "이전 지점",
+    next: "다음 지점",
+    audioControls: "오디오 컨트롤",
+    playbackPosition: "재생 위치",
+    source: "National Park Service 출처",
+    archive: "표본 아카이브",
+    volume: "VOL 61",
+    stripLabel: "테마 표본 내비게이션",
+    themeTabs: "표본 테마",
+    themeSpecimens: "테마 표본",
+    archiveSlipSummary: "프로젝트 아카이브 슬립 열기",
+    archiveSlip: "아카이브 슬립",
+    archiveCardLabel: "프로젝트 콜로폰",
+    colophon: "콜로폰",
+    archiveTitle: "옐로스톤 사운드 아틀라스",
+    archiveBody: "옐로스톤 공개 사운드 라이브러리를 바탕으로 표본 우표와 필드 노트로 구성한 정적 청취 루트입니다.",
+    repository: "저장소",
+    fullArchive: "전체 아카이브",
+    sourceLabel: "출처",
+    archiveFine:
+      "이것은 National Park Service 공식 제품이 아닙니다. NPS는 이 오디오를 퍼블릭 도메인으로 표시하지만, 사용자는 제3자 권리를 직접 확인해야 합니다. 제거가 필요한 파일은 issue를 열어 주세요.",
+    github: "GitHub",
+    webArchive: "Web Archive",
+    nationalParkService: "National Park Service",
+    statusLoaded: (count) => `${count}개 사운드 표본을 불러왔습니다`,
+    routeLoadFailed: "루트를 불러올 수 없습니다",
+    autoPlayFailed: "자동 재생을 시작할 수 없습니다.",
+    audioUnavailable: "이 표본의 오디오를 사용할 수 없습니다.",
+    language: "언어",
+    chooseLanguage: "언어 선택",
+    languageOption: (name) => `${name}로 보기`,
+    selectTheme: (theme, count) => `${theme}, 표본 ${count}개`,
+    selectStop: (title) => `${title} 선택`,
+    timeCurrent: "현재 시간",
+    timeTotal: "전체 시간",
+    keyboardSpace: "재생/일시정지",
+    keyboardPrev: "이전",
+    keyboardNext: "다음",
+    keyboardMinimize: "접기",
+    noScript: "이 경험에서 사운드 표본을 불러오려면 JavaScript가 필요합니다.",
+    shareText: (title, theme, time) => `옐로스톤 사운드 아틀라스: ${title} - ${theme}, ${time}.`,
+    shareTitle: (title) => `${title} - 옐로스톤 사운드 아틀라스`,
+    printCaption: (title, theme, time) => `${title} - ${theme} - ${time}`,
+    noteMeta: (theme, zone, time) => `${theme} - ${zone} - ${time}`,
+    eyebrow: (number) => `옐로스톤 - ${number}`,
+  },
+};
+
+const THEMES = {
+  Thermal: { zh: "地热", ja: "地熱", ko: "지열" },
+  Birds: { zh: "鸟类", ja: "鳥", ko: "새" },
+  Wildlife: { zh: "野生动物", ja: "野生動物", ko: "야생동물" },
+  Human: { zh: "人文", ja: "人の営み", ko: "사람의 흔적" },
+  Weather: { zh: "天气", ja: "天候", ko: "날씨" },
+  Ambient: { zh: "环境", ja: "環境音", ko: "환경음" },
+  Water: { zh: "水域", ja: "水", ko: "물" },
+};
+
+const TIMES = {
+  Dawn: { zh: "黎明", ja: "夜明け", ko: "새벽" },
+  Morning: { zh: "上午", ja: "朝", ko: "아침" },
+  Midday: { zh: "正午", ja: "昼", ko: "한낮" },
+  Afternoon: { zh: "下午", ja: "午後", ko: "오후" },
+  "Late Afternoon": { zh: "午后稍晚", ja: "午後遅く", ko: "늦은 오후" },
+  Dusk: { zh: "黄昏", ja: "夕暮れ", ko: "해질녘" },
+  Evening: { zh: "傍晚", ja: "夕方", ko: "저녁" },
+  Night: { zh: "夜晚", ja: "夜", ko: "밤" },
+};
+
+const ZONES = {
+  "Alpine meadow": { zh: "高山草甸", ja: "高山草地", ko: "고산 초원" },
+  "Black Sand Basin": { zh: "黑沙盆地", ja: "ブラックサンド・ベイスン", ko: "블랙 샌드 베이슨" },
+  "Canyon rim": { zh: "峡谷边缘", ja: "峡谷の縁", ko: "협곡 가장자리" },
+  "Cottonwood canopy": { zh: "三角叶杨树冠", ja: "コットンウッドの樹冠", ko: "미루나무 수관" },
+  "Deciduous forest": { zh: "落叶林", ja: "落葉樹林", ko: "낙엽수림" },
+  "Evening meadow": { zh: "傍晚草甸", ja: "夕方の草地", ko: "저녁 초원" },
+  "Forest edge": { zh: "森林边缘", ja: "森の縁", ko: "숲 가장자리" },
+  "Forest fire zone": { zh: "森林火场", ja: "森林火災跡", ko: "산불 지대" },
+  "Gibbon Geyser Basin": { zh: "吉本间歇泉盆地", ja: "ギボン・ガイザー・ベイスン", ko: "기번 가이저 베이슨" },
+  Grassland: { zh: "草地", ja: "草原", ko: "초원" },
+  "Grassland herd": { zh: "草原兽群", ja: "草原の群れ", ko: "초원의 무리" },
+  "Gravel bar": { zh: "砾石滩", ja: "砂礫州", ko: "자갈톱" },
+  "Historic trail": { zh: "历史步道", ja: "歴史的な道", ko: "역사 길" },
+  "Lake shore": { zh: "湖岸", ja: "湖岸", ko: "호숫가" },
+  "Lake surface": { zh: "湖面", ja: "湖面", ko: "호수 표면" },
+  "Lower Geyser Basin": { zh: "下间歇泉盆地", ja: "ローワー・ガイザー・ベイスン", ko: "로어 가이저 베이슨" },
+  "Mammoth Hot Springs": { zh: "猛犸温泉", ja: "マンモス・ホットスプリングス", ko: "매머드 온천" },
+  Marshland: { zh: "沼泽地", ja: "湿地", ko: "습지" },
+  "Morning chorus": { zh: "清晨合唱", ja: "朝のコーラス", ko: "아침 합창" },
+  "Morning soundscape": { zh: "清晨声景", ja: "朝のサウンドスケープ", ko: "아침 사운드스케이프" },
+  "Mountain stream": { zh: "山溪", ja: "山の小川", ko: "산속 계류" },
+  "Night soundscape": { zh: "夜间声景", ja: "夜のサウンドスケープ", ko: "밤의 사운드스케이프" },
+  "Norris Geyser Basin": { zh: "诺里斯间歇泉盆地", ja: "ノリス・ガイザー・ベイスン", ko: "노리스 가이저 베이슨" },
+  "Open meadow": { zh: "开阔草甸", ja: "開けた草地", ko: "열린 초원" },
+  "Park-wide soundscape": { zh: "公园整体声景", ja: "公園全体のサウンドスケープ", ko: "공원 전역 사운드스케이프" },
+  "Pine forest": { zh: "松林", ja: "松林", ko: "소나무 숲" },
+  "Pond margin": { zh: "池塘边缘", ja: "池の縁", ko: "연못 가장자리" },
+  "Prairie grassland": { zh: "草原", ja: "プレーリー草原", ko: "프레리 초원" },
+  "Riverside perch": { zh: "河岸栖枝", ja: "川辺の止まり木", ko: "강가 횃대" },
+  "Roaring Mountain": { zh: "咆哮山", ja: "ロアリング・マウンテン", ko: "로어링 마운틴" },
+  "Rutting ground": { zh: "发情场", ja: "繁殖期の場所", ko: "발정기 터" },
+  "Sagebrush slope": { zh: "鼠尾草坡地", ja: "セージブラシの斜面", ko: "세이지브러시 사면" },
+  "Shrub wetland": { zh: "灌丛湿地", ja: "低木湿地", ko: "관목 습지" },
+  "Summer storm": { zh: "夏季风暴", ja: "夏の嵐", ko: "여름 폭풍" },
+  "Temporary pool": { zh: "临时水池", ja: "一時的な水たまり", ko: "일시적 웅덩이" },
+  "Upper Geyser Basin": { zh: "上间歇泉盆地", ja: "アッパー・ガイザー・ベイスン", ko: "어퍼 가이저 베이슨" },
+  "Valley floor": { zh: "谷底", ja: "谷底", ko: "계곡 바닥" },
+  "Wetland margin": { zh: "湿地边缘", ja: "湿地の縁", ko: "습지 가장자리" },
+  "Wetland marsh": { zh: "湿地沼泽", ja: "湿原", ko: "습지 늪" },
+  "Wetland meadow": { zh: "湿地草甸", ja: "湿地草原", ko: "습지 초원" },
+  "Winter trail": { zh: "冬季小径", ja: "冬の道", ko: "겨울 길" },
+  "Yellowstone Lake": { zh: "黄石湖", ja: "イエローストーン湖", ko: "옐로스톤 호수" },
+};
+
+const TITLES = {
+  "American Coots": { zh: "美洲骨顶鸡", ja: "アメリカオオバン", ko: "아메리카물닭" },
+  "American Robin": { zh: "美洲知更鸟", ja: "コマツグミ", ko: "아메리카울새" },
+  "Bird Chorus": { zh: "鸟鸣合唱", ja: "鳥の合唱", ko: "새들의 합창" },
+  "Common Yellowthroat": { zh: "普通黄喉地莺", ja: "カオグロアメリカムシクイ", ko: "커먼 옐로스로트" },
+  "Dawn Chorus": { zh: "黎明合唱", ja: "夜明けの合唱", ko: "새벽 합창" },
+  "Red Fox": { zh: "赤狐", ja: "アカギツネ", ko: "붉은여우" },
+  "Red-Winged Blackbird": { zh: "红翅黑鹂", ja: "ハゴロモガラス", ko: "붉은날개검은새" },
+  "Sandhill Crane": { zh: "沙丘鹤", ja: "カナダヅル", ko: "캐나다두루미" },
+  Soundscapes: { zh: "声景", ja: "サウンドスケープ", ko: "사운드스케이프" },
+  "American Dipper": { zh: "美洲河乌", ja: "アメリカカワガラス", ko: "아메리카물까마귀" },
+  "Bald Eagle": { zh: "白头海雕", ja: "ハクトウワシ", ko: "흰머리수리" },
+  "Canada Goose": { zh: "加拿大雁", ja: "カナダガン", ko: "캐나다기러기" },
+  "Clark's Nutcracker": { zh: "克拉克星鸦", ja: "ハイイロホシガラス", ko: "클라크호시까마귀" },
+  "Common Raven": { zh: "渡鸦", ja: "ワタリガラス", ko: "큰까마귀" },
+  Killdeer: { zh: "双领鸻", ja: "フタオビチドリ", ko: "킬디어" },
+  "Mountain Bluebird": { zh: "山蓝鸲", ja: "ムジルリツグミ", ko: "마운틴 블루버드" },
+  "Red Squirrel": { zh: "红松鼠", ja: "アカリス", ko: "붉은다람쥐" },
+  "Ruffed Grouse": { zh: "披肩榛鸡", ja: "エリマキライチョウ", ko: "목도리뇌조" },
+  "Savannah Sparrow": { zh: "萨凡纳鹀", ja: "クサチヒメドリ", ko: "사바나참새" },
+  Snowmobile: { zh: "雪地摩托", ja: "スノーモービル", ko: "스노모빌" },
+  "Townsend's Solitaire": { zh: "汤氏孤鸫", ja: "タウンゼントハエトリツグミ", ko: "타운센드솔리테어" },
+  "Uinta Ground Squirrel": { zh: "尤因塔地松鼠", ja: "ユインタジリス", ko: "유인타땅다람쥐" },
+  "Warbling Vireo": { zh: "鸣绿鹃", ja: "サエズリモズモドキ", ko: "노래비레오" },
+  "Western Meadow Lark": { zh: "西部草地鹨", ja: "ニシマキバドリ", ko: "서부초원종다리" },
+  "Anemone Geyser": { zh: "海葵间歇泉", ja: "アネモネ・ガイザー", ko: "아네모네 간헐천" },
+  "Anemone Geysers": { zh: "海葵间歇泉群", ja: "アネモネ・ガイザー群", ko: "아네모네 간헐천군" },
+  "Artist Paint Pots": { zh: "艺术家彩泥锅", ja: "アーティスト・ペイントポット", ko: "아티스트 페인트 팟" },
+  "Beehive Geyser": { zh: "蜂巢间歇泉", ja: "ビーハイブ・ガイザー", ko: "비하이브 간헐천" },
+  "Beryl Spring": { zh: "绿柱石泉", ja: "ベリル・スプリング", ko: "베릴 스프링" },
+  "Bison Eating": { zh: "野牛进食", ja: "バイソンの採食", ko: "먹이를 먹는 들소" },
+  "Castle Geyser": { zh: "城堡间歇泉", ja: "キャッスル・ガイザー", ko: "캐슬 간헐천" },
+  "Cliff Geyser": { zh: "悬崖间歇泉", ja: "クリフ・ガイザー", ko: "클리프 간헐천" },
+  "Ear Spring": { zh: "耳泉", ja: "イヤー・スプリング", ko: "이어 스프링" },
+  "Fountain Paint Pot": { zh: "喷泉彩泥锅", ja: "ファウンテン・ペイントポット", ko: "파운틴 페인트 팟" },
+  "Grand Geyser": { zh: "大间歇泉", ja: "グランド・ガイザー", ko: "그랜드 간헐천" },
+  "Horse-Drawn Wagon": { zh: "马拉车", ja: "馬車", ko: "말이 끄는 마차" },
+  "Old Faithful Geyser": { zh: "老忠实间歇泉", ja: "オールド・フェイスフル・ガイザー", ko: "올드 페이스풀 간헐천" },
+  "Puff 'n Stuff Geyser": { zh: "Puff 'n Stuff 间歇泉", ja: "パフンスタッフ・ガイザー", ko: "퍼프 앤 스터프 간헐천" },
+  "Sawmill Geyser": { zh: "锯木厂间歇泉", ja: "ソーミル・ガイザー", ko: "소밀 간헐천" },
+  "Spouter Geyser": { zh: "喷涌间歇泉", ja: "スパウター・ガイザー", ko: "스파우터 간헐천" },
+  "Veteran Geyser": { zh: "老兵间歇泉", ja: "ベテラン・ガイザー", ko: "베테랑 간헐천" },
+  "Vixen Geyser": { zh: "雌狐间歇泉", ja: "ヴィクセン・ガイザー", ko: "빅슨 간헐천" },
+  "Black Growler Steam Vent": { zh: "黑咆哮蒸汽孔", ja: "ブラック・グラウラー蒸気孔", ko: "블랙 그라울러 증기공" },
+  "Black Sand Pool": { zh: "黑沙池", ja: "ブラックサンド・プール", ko: "블랙 샌드 풀" },
+  Fire: { zh: "火", ja: "火", ko: "불" },
+  Fumaroles: { zh: "喷气孔", ja: "噴気孔", ko: "분기공" },
+  "Hurricane Vent": { zh: "飓风喷气孔", ja: "ハリケーン・ベント", ko: "허리케인 벤트" },
+  "Scissors Springs": { zh: "剪刀泉", ja: "シザーズ・スプリングス", ko: "시저스 스프링스" },
+  "The Dragon's Mouth": { zh: "龙口泉", ja: "ドラゴンズ・マウス", ko: "드래곤스 마우스" },
+  Thunder: { zh: "雷声", ja: "雷", ko: "천둥" },
+  "Bison Rut": { zh: "野牛发情季", ja: "バイソンの繁殖期", ko: "들소 발정기" },
+  "Common Loon": { zh: "普通潜鸟", ja: "ハシグロアビ", ko: "큰회색머리아비" },
+  "Singing Lake": { zh: "歌唱之湖", ja: "歌う湖", ko: "노래하는 호수" },
+  "Boreal Chorus Frogs": { zh: "北方合唱蛙", ja: "ボリアルコーラスガエル", ko: "북방합창개구리" },
+  Elk: { zh: "麋鹿", ja: "エルク", ko: "엘크" },
+  "Wilson's Snipe": { zh: "威尔逊沙锥", ja: "ウィルソンタシギ", ko: "윌슨도요" },
+  Coyotes: { zh: "郊狼", ja: "コヨーテ", ko: "코요테" },
+  "Spadefoot Toad": { zh: "铲足蟾", ja: "スキアシガエル", ko: "삽발두꺼비" },
+  Wolves: { zh: "狼群", ja: "オオカミ", ko: "늑대" },
+};
+
+function lookup(table, value, locale) {
+  if (locale === DEFAULT_LOCALE) return value;
+  return table[value]?.[locale] || value;
+}
+
+function templateDescription(stop, locale, title, theme, zone) {
+  if (locale === "zh") {
+    if (stop.theme === "Thermal") return `${title}把地热、蒸汽与地下压力带入${zone}的声场。`;
+    if (stop.theme === "Birds") return `${title}的鸣声在${zone}展开，标记这条黄石路线的时间层次。`;
+    if (stop.theme === "Wildlife") return `${title}穿过${zone}，让野生动物的距离与方向变得可听见。`;
+    if (stop.theme === "Water") return `${title}把水面与岸线的空气带进这枚声音标本。`;
+    if (stop.theme === "Weather") return `${title}记录天气经过黄石地形时留下的声压与回响。`;
+    if (stop.theme === "Human") return `${title}保留了人在黄石景观中移动时留下的声音痕迹。`;
+    return `${title}记录了${zone}里不断变化的黄石环境声。`;
+  }
+  if (locale === "ja") {
+    if (stop.theme === "Thermal") return `${title}は、地熱、蒸気、地下の圧力を${zone}の音風景へ引き込みます。`;
+    if (stop.theme === "Birds") return `${title}の声が${zone}に広がり、このルートの時間の層を示します。`;
+    if (stop.theme === "Wildlife") return `${title}が${zone}を横切り、野生動物との距離と方向を聞こえるものにします。`;
+    if (stop.theme === "Water") return `${title}は、水面と岸辺の空気をこの音標本に運び込みます。`;
+    if (stop.theme === "Weather") return `${title}は、天候が地形を通るときの圧力と反響を記録します。`;
+    if (stop.theme === "Human") return `${title}は、人がイエローストーンを移動するときの音の痕跡を残します。`;
+    return `${title}は、${zone}で変化し続ける環境音を記録します。`;
+  }
+  if (locale === "ko") {
+    if (stop.theme === "Thermal") return `${title}는 지열, 증기, 지하 압력을 ${zone}의 소리 풍경으로 끌어옵니다.`;
+    if (stop.theme === "Birds") return `${title}의 소리가 ${zone}에 퍼지며 이 루트의 시간 층을 드러냅니다.`;
+    if (stop.theme === "Wildlife") return `${title}가 ${zone}을 지나며 야생동물과의 거리와 방향을 들리게 합니다.`;
+    if (stop.theme === "Water") return `${title}는 수면과 물가의 공기를 이 사운드 표본에 담습니다.`;
+    if (stop.theme === "Weather") return `${title}는 날씨가 옐로스톤 지형을 지날 때의 압력과 울림을 기록합니다.`;
+    if (stop.theme === "Human") return `${title}는 사람이 옐로스톤 풍경 속을 이동하며 남긴 소리의 흔적을 보존합니다.`;
+    return `${title}는 ${zone}에서 계속 변하는 옐로스톤의 환경음을 기록합니다.`;
+  }
+  return stop.description;
+}
+
+function templateFieldNote(stop, locale, title, theme, zone, time) {
+  if (locale === DEFAULT_LOCALE) return stop.fieldNote || stop.description;
+  if (locale === "zh") return `${time}，${title}把${theme}的质地压进${zone}。这枚标本不解释景观，而是让它以声音显影。`;
+  if (locale === "ja") return `${time}、${title}は${theme}の質感を${zone}に刻みます。この標本は景観を説明するのではなく、音として立ち上げます。`;
+  if (locale === "ko") return `${time}, ${title}는 ${theme}의 결을 ${zone}에 새깁니다. 이 표본은 풍경을 설명하기보다 소리로 드러냅니다.`;
+  return stop.fieldNote || stop.description;
+}
+
+export function normalizeLocale(locale) {
+  return SUPPORTED_LOCALES.includes(locale) ? locale : DEFAULT_LOCALE;
+}
+
+export function localeFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const requested = normalizeLocale(params.get("lang"));
+  if (requested !== DEFAULT_LOCALE || params.has("lang")) return requested;
+
+  try {
+    return normalizeLocale(window.localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return DEFAULT_LOCALE;
+  }
+}
+
+export function setStoredLocale(locale) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, normalizeLocale(locale));
+  } catch {
+    // Locale persistence is a progressive enhancement.
+  }
+}
+
+export function uiText(locale) {
+  return UI_COPY[normalizeLocale(locale)] || UI_COPY[DEFAULT_LOCALE];
+}
+
+export function localizeStop(stop, locale) {
+  const normalized = normalizeLocale(locale);
+  const title = lookup(TITLES, stop.title, normalized);
+  const theme = lookup(THEMES, stop.theme, normalized);
+  const timeOfDay = lookup(TIMES, stop.timeOfDay, normalized);
+  const zoneLabel = lookup(ZONES, stop.zoneLabel, normalized);
+
+  return {
+    ...stop,
+    sourceTitle: stop.title,
+    sourceTheme: stop.theme,
+    title,
+    theme,
+    timeOfDay,
+    zoneLabel,
+    description: templateDescription(stop, normalized, title, theme, zoneLabel),
+    fieldNote: templateFieldNote(stop, normalized, title, theme, zoneLabel, timeOfDay),
+    credit: localizedCredit(stop, normalized),
+  };
+}
+
+export function localizeThemeName(theme, locale) {
+  return lookup(THEMES, theme, normalizeLocale(locale));
+}
+
+export function localizeTimeLabel(timeOfDay, locale) {
+  return lookup(TIMES, timeOfDay, normalizeLocale(locale));
+}
+
+export function localizedCredit(stop, locale) {
+  const hasImage = Boolean(stop.imagePath);
+  if (locale === "zh") return hasImage ? "音频与图像由 National Park Service 提供。" : "音频由 National Park Service 提供。";
+  if (locale === "ja") return hasImage ? "音声と画像は National Park Service 提供。" : "音声は National Park Service 提供。";
+  if (locale === "ko") return hasImage ? "오디오와 이미지는 National Park Service 제공." : "오디오는 National Park Service 제공.";
+  if (hasImage) return stop.credit;
+  return stop.credit.replace("Audio and image", "Audio");
+}
+
+export function shareText(stop, locale) {
+  const copy = uiText(locale);
+  const localized = localizeStop(stop, locale);
+  return copy.shareText(localized.title, localized.theme, localized.timeOfDay);
+}
+
+export function shareHashtags(locale) {
+  if (locale === "zh") return "Yellowstone,黄石,Soundscape";
+  if (locale === "ja") return "Yellowstone,イエローストーン,Soundscape";
+  if (locale === "ko") return "Yellowstone,옐로스톤,Soundscape";
+  return "Yellowstone,Soundscape";
+}

--- a/docs/superpowers/plans/2026-05-11-radical-atlas-i18n-a11y.md
+++ b/docs/superpowers/plans/2026-05-11-radical-atlas-i18n-a11y.md
@@ -1,0 +1,74 @@
+# Radical Atlas I18n And Accessibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add English, Simplified Chinese, Japanese, and Korean support to the existing radical Yellowstone Sound Atlas without replacing its specimen-stamp visual system.
+
+**Architecture:** Preserve `atlas/index.html`, `atlas/css/main.css`, `atlas/js/app.js`, and the curated 61+ stop data contract. Add `atlas/js/i18n.js` as a small translation layer that localizes UI strings, themes, times, common zones, and generated stop prose at render time, with English data as the source of truth and safe fallback for proper nouns.
+
+**Tech Stack:** Static HTML, CSS custom properties, vanilla JavaScript modules, native audio, JSON fetch, `pytest`, BeautifulSoup static checks, and local Playwright browser QA.
+
+---
+
+## File Structure
+
+- Create `atlas/js/i18n.js`: supported locale constants, UI copy, title/theme/time/zone dictionaries, stop localization helpers, URL/localStorage locale helpers.
+- Modify `atlas/js/app.js`: import i18n helpers, add `state.locale`, render localized copy, preserve selected stop/theme, and include current locale in share URLs.
+- Modify `atlas/index.html`: add an accessible language switcher and stable IDs for static copy that should update by locale.
+- Modify `atlas/css/main.css`: style the language switcher to match the stamp UI, with focus-visible, touch-safe sizing, and mobile behavior.
+- Modify `tests/test_atlas_static.py`: lock the language switcher, i18n module reference, and CSS accessibility contract.
+- Modify `README.md`: document atlas language support and preview workflow.
+
+---
+
+### Task 1: Lock The Correct Radical I18n Contract
+
+**Files:**
+- Modify: `tests/test_atlas_static.py`
+
+- [ ] Add a static test requiring `atlas/index.html` to include `#language-switcher`, four buttons with `data-locale` values `en`, `zh`, `ja`, `ko`, and `aria-label="Language"`.
+- [ ] Add a static test requiring `atlas/js/app.js` to import `./i18n.js`.
+- [ ] Add a static test requiring `atlas/css/main.css` to include `.language-switcher`, `.language-switcher button[aria-pressed="true"]`, and `.language-switcher button:focus-visible`.
+- [ ] Run `pytest tests/test_atlas_static.py -v`; expect failure because the radical page has no language switcher yet.
+
+### Task 2: Add The I18n Module
+
+**Files:**
+- Create: `atlas/js/i18n.js`
+
+- [ ] Export `SUPPORTED_LOCALES`, `DEFAULT_LOCALE`, `LOCALE_LABELS`, `normalizeLocale`, `localeFromUrl`, `setStoredLocale`, `uiText`, `localizeStop`, `shareText`, `shareHashtags`, and `localizedCredit`.
+- [ ] Keep English as exact source-of-truth copy.
+- [ ] Localize themes, times, common zones, major proper names, archive/slip UI, controls, status, and generated field-note prose for Chinese, Japanese, and Korean.
+- [ ] Run `node --check atlas/js/i18n.js`; expect pass.
+
+### Task 3: Wire Runtime Locale State
+
+**Files:**
+- Modify: `atlas/index.html`
+- Modify: `atlas/js/app.js`
+
+- [ ] Add the language switcher to the stamp header without changing the stamp/card hierarchy.
+- [ ] Import i18n helpers in `app.js`.
+- [ ] Add `state.locale`, derive it from `?lang=` or localStorage, and update `document.documentElement.lang`.
+- [ ] Render localized labels in player, mini player, backdrop note, theme tabs, chips, archive slip, share dock, status messages, keyboard hints, and aria labels.
+- [ ] Re-render route UI on locale switch without changing selected stop or active theme.
+- [ ] Run `pytest tests/test_atlas_static.py -v`; expect pass.
+
+### Task 4: Style Language Controls In The Existing Design
+
+**Files:**
+- Modify: `atlas/css/main.css`
+
+- [ ] Style the language switcher as compact stamp controls, not a new card.
+- [ ] Ensure every language button is at least 34px high on desktop and 44px high on touch layouts.
+- [ ] Add active, hover, active-press, disabled-safe, and focus-visible states.
+- [ ] Add mobile layout rules so the switcher does not collide with stamp metadata.
+
+### Task 5: Verify
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] Document the four-language atlas in English and Chinese README sections.
+- [ ] Run `pytest -v`, `node --check atlas/js/app.js`, `node --check atlas/js/i18n.js`, and `git diff --check`.
+- [ ] Run browser QA on `http://127.0.0.1:8000/atlas/`: default English, switch zh/ja/ko, selected stop preserved, theme tabs/chips/player text update, share URL includes `lang`, no console/page errors, no mobile horizontal overflow.

--- a/tests/test_atlas_static.py
+++ b/tests/test_atlas_static.py
@@ -124,6 +124,14 @@ def test_app_localizes_accessibility_landmarks():
     assert 'ui.audioControls.setAttribute("aria-label", text.audioControls);' in script
 
 
+def test_language_menu_focus_recovers_from_trigger_reentry():
+    script = JS_PATH.read_text(encoding="utf-8")
+
+    assert "const currentIndex = items.indexOf(document.activeElement);" in script
+    assert "if (currentIndex === -1)" in script
+    assert "activeLanguageItem()?.focus();" in script
+
+
 def test_language_switcher_has_accessible_interaction_styles():
     css = CSS_PATH.read_text(encoding="utf-8")
 

--- a/tests/test_atlas_static.py
+++ b/tests/test_atlas_static.py
@@ -113,6 +113,17 @@ def test_app_imports_i18n_module():
     assert 'from "./i18n.js"' in script
 
 
+def test_app_localizes_accessibility_landmarks():
+    script = JS_PATH.read_text(encoding="utf-8")
+
+    assert 'stage: getEl("#stage")' in script
+    assert 'shareDock: getEl("#share-dock")' in script
+    assert 'audioControls: getEl("#audio-controls")' in script
+    assert 'ui.stage.setAttribute("aria-label", text.siteLabel);' in script
+    assert 'ui.shareDock.setAttribute("aria-label", text.shareDock);' in script
+    assert 'ui.audioControls.setAttribute("aria-label", text.audioControls);' in script
+
+
 def test_language_switcher_has_accessible_interaction_styles():
     css = CSS_PATH.read_text(encoding="utf-8")
 
@@ -328,7 +339,7 @@ def test_minimized_player_shows_curated_field_note_next_to_print():
     assert "left: calc(" in css
     assert "max-width: min(28vw, 360px)" in css
     assert page.find(class_="backdrop-note-kicker").get_text(strip=True) == "FIELD NOTE"
-    assert "descriptionForStop" in script
+    assert "descriptionForStop" not in script
     assert "ui.backdropNoteBody.textContent = localized.fieldNote || localized.description;" in script
     assert "ui.desc.textContent = localized.fieldNote || localized.description;" in script
 

--- a/tests/test_atlas_static.py
+++ b/tests/test_atlas_static.py
@@ -79,6 +79,60 @@ def test_index_references_split_css_and_javascript_assets():
     assert "js/app.js" in script_sources
 
 
+def test_index_contains_accessible_language_menu():
+    page = load_page()
+
+    switcher = page.find(id="language-switcher")
+    trigger = page.find(id="language-menu-button")
+    menu = page.find(id="language-menu")
+
+    assert switcher
+    assert switcher.get("aria-label") == "Language"
+    assert trigger
+    assert trigger.get("aria-haspopup") == "menu"
+    assert trigger.get("aria-expanded") == "false"
+    assert trigger.get("aria-controls") == "language-menu"
+    icon = trigger.find("svg", attrs={"data-icon": "languages"})
+    assert icon
+    assert "A/A" not in trigger.get_text("", strip=True)
+    assert menu
+    assert menu.get("role") == "menu"
+    assert menu.has_attr("hidden")
+    assert [button.get("data-locale") for button in menu.find_all("button")] == [
+        "en",
+        "zh",
+        "ja",
+        "ko",
+    ]
+    assert {button.get("role") for button in menu.find_all("button")} == {"menuitemradio"}
+
+
+def test_app_imports_i18n_module():
+    script = JS_PATH.read_text(encoding="utf-8")
+
+    assert 'from "./i18n.js"' in script
+
+
+def test_language_switcher_has_accessible_interaction_styles():
+    css = CSS_PATH.read_text(encoding="utf-8")
+
+    assert ".language-switcher" in css
+    assert ".language-menu-button" in css
+    assert ".language-menu" in css
+    assert ".language-menu[hidden]" in css
+    assert '.language-menu button[aria-checked="true"]' in css
+    assert ".language-menu-button:focus-visible" in css
+
+
+def test_mobile_language_switcher_moves_out_of_bottom_strip():
+    css = CSS_PATH.read_text(encoding="utf-8")
+
+    assert "top: max(14px, calc(env(safe-area-inset-top) + 14px))" in css
+    assert "right: max(14px, calc(env(safe-area-inset-right) + 14px))" in css
+    assert "top: calc(100% + 8px)" in css
+    assert "bottom: auto" in css
+
+
 def test_index_exposes_site_level_social_preview_metadata():
     page = load_page()
 
@@ -275,8 +329,8 @@ def test_minimized_player_shows_curated_field_note_next_to_print():
     assert "max-width: min(28vw, 360px)" in css
     assert page.find(class_="backdrop-note-kicker").get_text(strip=True) == "FIELD NOTE"
     assert "descriptionForStop" in script
-    assert "ui.backdropNoteBody.textContent = descriptionForStop(stop);" in script
-    assert "ui.desc.textContent = descriptionForStop(stop);" in script
+    assert "ui.backdropNoteBody.textContent = localized.fieldNote || localized.description;" in script
+    assert "ui.desc.textContent = localized.fieldNote || localized.description;" in script
 
 
 def test_field_note_uses_postal_card_style_and_selectable_text():
@@ -329,7 +383,7 @@ def test_minimized_player_exposes_lightweight_share_controls():
     assert "navigator.clipboard.writeText" in script
     assert "shareUrlForStop" in script
     assert "share/${encodeURIComponent(stop.id)}/" in script
-    assert "return new URL(`share/${encodeURIComponent(stop.id)}/`, atlasBaseUrl()).toString();" in script
+    assert 'url.searchParams.set("lang", state.locale);' in script
     assert "updateShareTargets(stop);" in script
     assert "platform.twitter.com/widgets.js" not in page.decode()
 
@@ -413,7 +467,7 @@ def test_mobile_minimized_deck_reserves_bottom_strip_safe_area():
     assert ".player-card.is-minimized .mini-rule" in css
     assert ".player-card.is-minimized .mini-copy" in css
     assert ".player-card.is-minimized .mini-play-btn" in css
-    assert "grid-template-rows: 38px minmax(0, 1fr)" in css
+    assert "grid-template-rows: 44px minmax(0, 1fr)" in css
 
 
 def test_mobile_theme_tabs_use_compact_full_labels_without_ellipsis():


### PR DESCRIPTION
## Summary
- Add runtime i18n support for English, Simplified Chinese, Japanese, and Korean across the atlas player, theme navigation, share text, archive copy, and URL state.
- Add an accessible language menu with a mature language icon, keyboard support, Escape/outside-click dismissal, and mobile-safe positioning.
- Cover the language menu, i18n wiring, and mobile placement with static tests and document the localized atlas behavior.

## Test Plan
- [x] pytest -v
- [x] node --check atlas/js/app.js && node --check atlas/js/i18n.js
- [x] git diff --check
- [x] Playwright smoke: en/zh/ja/ko switching, share lang URL, mobile menu placement, no horizontal overflow
