### PR TITLE
Fix urllib3 security alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ idna==3.13
 requests==2.33.1
 soupsieve==2.8.3
 tqdm==4.67.3
-urllib3==2.6.3
+urllib3==2.7.0


### PR DESCRIPTION
## Summary
- Bump `urllib3` from `2.6.3` to `2.7.0` to address Dependabot alerts #25 and #26.

## Verification
- `/Users/rosu/Coding/YSL/.venv/bin/python -m pip install -r requirements.txt`
- `/Users/rosu/Coding/YSL/.venv/bin/python -m pip check`
- `/Users/rosu/Coding/YSL/.venv/bin/python -m pytest -q`
- `/Users/rosu/Coding/YSL/.venv/bin/python scripts/build_atlas_route.py --check`
- `/Users/rosu/Coding/YSL/.venv/bin/python -m black --check spider.py tests/`
- `/Users/rosu/Coding/YSL/.venv/bin/python -m flake8 spider.py tests/`
- `git diff --check`